### PR TITLE
:sparkles: feat: SJRA-668 Add support for Kubernetes based Radiant Portal Pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,11 +185,23 @@ git clone git@github.com:radiant-network/radiant-portal-pipeline.git
 ```
 
 Then in a new terminal, run the following command to mount the dags directory in minikube:
-```
+``` 
 minikube mount $(pwd)/radiant-portal-pipeline/radiant:/opt/airflow/dags/radiant
 ```
 Let this command run in a separate terminal while you are working with Airflow.
 
+## Pre-building the Radiant task operator image (~6 minutes)
+
+(This step is optional if you have access to the `radiant-network` Github packages, otherwise it is required.)
+
+Inside the `radiant-portal-pipeline` directory, run the following command to build the Radiant task operator image:
+
+```
+eval $(minikube -p minikube docker-env)  # To ensure the image is built inside minikube's docker environment
+docker build -t ghcr.io/radiant-network/radiant-airflow-task-operator:1.0.5 -f Dockerfile.radiant.operator .
+```
+
+**Important note:** Ensure the image's name and tag matches with the `RADIANT_TASK_OPERATOR_IMAGE` from the `values/airflow-values.yaml` file.
 
 ## Install airflow volumes for logs and dags
 ```

--- a/k8s/api/radiant-api-deployments.yml
+++ b/k8s/api/radiant-api-deployments.yml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: ghcr.io/radiant-network/radiant-api:d26a98a-1754421365
+          image: ghcr.io/radiant-network/radiant-api:f83915a-1759275255
           env:
             - name: DB_USERNAME
               value: root

--- a/k8s/ui/radiant-ui-deployments.yml
+++ b/k8s/ui/radiant-ui-deployments.yml
@@ -15,7 +15,7 @@ spec:
         app: radiant-portal-ui
     spec:
       containers:
-      - image: ghcr.io/radiant-network/radiant-portal:d26a98a-1754421365 # {"$imagepolicy": "cqdg-qa-fluxcd:radiant-portal-ui"}
+      - image: ghcr.io/radiant-network/radiant-portal:f83915a-1759275255 # {"$imagepolicy": "cqdg-qa-fluxcd:radiant-portal-ui"}
         name: radiant-portal-ui
         ports:
         - containerPort: 3000

--- a/values/airflow-values.yaml
+++ b/values/airflow-values.yaml
@@ -70,7 +70,16 @@ extraEnv: |
     value: "mysql://root@radiant-starrocks-fe:9030/radiant"  
   - name: AIRFLOW_CONN_RADIANT_POSTGRES_CONN
     value: "postgresql://postgres:postgres@postgres:5432/radiant"
-
+  - name: AIRFLOW_CONN_KUBERNETES_CONN
+    value: "kubernetes://?extra__kubernetes__in_cluster=True&extra__kubernetes__namespace=radiant"
+  - name: RADIANT_TASK_OPERATOR_KUBERNETES_NAMESPACE
+    value: radiant
+  - name: RADIANT_TASK_OPERATOR_IMAGE
+    value: "ghcr.io/radiant-network/radiant-airflow-task-operator:1.0.5"
+  - name: RADIANT_TASK_OPERATOR_PYTHONPATH
+    value: "/opt/radiant"
+  - name: RADIANT_TASK_OPERATOR_LD_LIBRARY_PATH
+    value: "/usr/local/lib:$LD_LIBRARY_PATH"
 
 #env:
 #  - name: AIRFLOW__CORE__DAGS_FOLDER


### PR DESCRIPTION
⚠️ This PR cannot be merged before work is completed in the `radiant-portal-pipeline` repository. 

---

## Context

With https://github.com/radiant-network/architecture/blob/main/decisions/0007-ECS-Airflow-operators.md architectural decision taken, the radiant portal pipeline is migrating some of its task operators to Kubernetes or AWS ECS (depending on the runtime environment). 

Because the current project runs on `minikube` we need to ensure the instructions are updated to allow users to run their ETL pipelines in K8s pods in `minikube`

## Contribution

- Add an additional instruction to ensure the `radiant-task-operator` docker image is built in the minikube environment. 
- Add additional `airflow-values` for the new Kubernetes task operator. 
- Update the `api` and `ui` tags to their latest versions. 