### PR TITLE
Feat/sjra 1184 allow to use sandbox in portal unit test

### DIFF
--- a/k8s/polaris/init/radiant-polaris-init-catalog-job.yaml
+++ b/k8s/polaris/init/radiant-polaris-init-catalog-job.yaml
@@ -27,8 +27,6 @@ spec:
               value: "radiant"
             - name: CATALOG_NAME
               value: "polaris"
-            - name: CATALOG_ENDPOINT
-              value: "http://radiant-minio:9000"
             - name: CATALOG_WAREHOUSE
               value: "s3://warehouse/polaris"
             - name: POLARIS_SERVICE_HOST

--- a/k8s/polaris/init/radiant-polaris-init-catalog-script.yaml
+++ b/k8s/polaris/init/radiant-polaris-init-catalog-script.yaml
@@ -77,8 +77,7 @@ data:
     create_catalog_if_not_exists() {
       local token="$1"
       local catalog_name="$2"
-      local catalog_endpoint="$3"
-      local catalog_warehouse="$4"
+      local catalog_warehouse="$3"
       local payload="{
         \"catalog\": {
           \"name\": \"${catalog_name}\",
@@ -90,7 +89,6 @@ data:
           \"storageConfigInfo\": {
             \"storageType\": \"S3\",
             \"allowedLocations\": [\"$catalog_warehouse\"],
-            \"endpoint\": \"$catalog_endpoint\",
             \"pathStyleAccess\": true,
             \"stsUnavailable\": true
           }
@@ -158,7 +156,7 @@ data:
       fi
       echo "✅ Obtained access token"
       
-      create_catalog_if_not_exists "$token" "$CATALOG_NAME" "$CATALOG_ENDPOINT" "$CATALOG_WAREHOUSE"
+      create_catalog_if_not_exists "$token" "$CATALOG_NAME" "$CATALOG_WAREHOUSE"
       grant_privilege_if_not_exists "$token" "$CATALOG_NAME" "catalog_admin" "CATALOG_MANAGE_CONTENT"
       create_namespace_if_not_exists "$token" "$CATALOG_NAME" "$NAMESPACE"
   


### PR DESCRIPTION
## 📌 Context

Avoid storing the catalog endpoint URL when creating the catalog in Polaris.

Including the endpoint causes issues when running unit tests in the sandbox environment (e.g., with radiant-portal-pipeline), because the stored URL points to a Minikube address that is not accessible outside the cluster.

For some clients, such as PyIceberg, specifying an endpoint in the catalog configuration forces the client to use that endpoint, overriding any client-side settings. By omitting the endpoint from the catalog, clients will instead use the endpoint specified in their own configuration, allowing for flexibility depending on whether access is from inside or outside Minikube.

Without this change, users must manually add a line to their /etc/hosts file to map radiant-minio to 127.0.0.1, which is inconvenient.

## 📝 Changes

<!-- List the main changes in this PR. -->

- Modify polaris init job and script to avoid storing the catalog endpoint url

## ☑️ TO-DOs

<!-- Tasks that still need to be completed before merging. -->

- [ ] 

## 🧪 Tests

<!-- Describe any new or updated tests, how to run them, and relevant results. -->

-  Started the sandbox locally and run the sequence of dags as instructed in the readme
-  Make sure that there is no mapping to minio host in /etc/hosts file. Then start the sandbox locally and run`make test-integration` command. All tests should pass.
- Idem above, but for slow tests `make test-integration-slow`

## 🔗 Related Issues

<!-- Link to any relevant GitHub issues, Jira tickets, etc. -->

-

## 👀 Notes for Reviewers

<!-- Anything reviewers should pay special attention to. Questions, caveats, tricky parts, etc. -->

- 